### PR TITLE
Allow passing both infuraKey and custom rpc to fix Celo wallets

### DIFF
--- a/src/modules/select/wallets/wallet-connect.ts
+++ b/src/modules/select/wallets/wallet-connect.ts
@@ -47,9 +47,13 @@ function walletConnect(
       const balanceProvider = createProvider({ rpcUrl })
 
       if (infuraKey && rpc) {
-        throw new Error(
-          'WalletConnect requires  an Infura ID or a custom RPC object but not both.'
-        )
+        // Commenting out this requirement for Celo wallets where the custom rpc is needed.
+        // Note: the custom rpc will only be used if the chainId is not already in @walletconnect/utils
+        // See https://github.com/WalletConnect/walletconnect-monorepo/blob/0871582be273f8c21bb1351315d649ea47ee70b7/packages/helpers/utils/src/misc.ts#L53-L71
+        // and https://github.com/WalletConnect/walletconnect-monorepo/blob/0871582be273f8c21bb1351315d649ea47ee70b7/packages/helpers/utils/src/constants.ts#L28-L34
+        // throw new Error(
+        //   'WalletConnect requires  an Infura ID or a custom RPC object but not both.'
+        // )
       }
 
       const provider = new WalletConnectProvider({


### PR DESCRIPTION
### Description

This removes the error thrown when both `infuraKey` and `rpc` options are passed to WalletConnect.

This was needed to make Valora (and other Celo wallets) work with PoolTogether via WalletConnect .
This shouldn't break other WalletConnect integrations.

See also the related changes in https://github.com/pooltogether/pooltogether-hooks/pull/9

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
